### PR TITLE
Correspondance tables

### DIFF
--- a/breadboard.py
+++ b/breadboard.py
@@ -1,4 +1,5 @@
 """
+breadboard.py
 This module provides a Breadboard class for circuit design using the Tkinter Canvas library.
 It includes methods for mouse tracking, and matrix filling 
 for breadboards with 830 and 1260 points. Additionally, it provides a method for generating circuit layouts 

--- a/component_sketch.py
+++ b/component_sketch.py
@@ -1,4 +1,5 @@
 """
+component_sketch.py
 This module provides a class `ComponentSketcher` for sketching and manipulating electronic components on 
 a Tkinter canvas. It includes methods for drawing various components such as chips, wires, and pins, as 
 well as handling events like dragging and clicking.
@@ -2474,6 +2475,7 @@ class ComponentSketcher:
         coord = kwargs.get("coord", [])
         element_type = kwargs.get("type", INPUT)
         color = kwargs.get("color", "#479dff")
+        assigned_pin = kwargs.get("assigned_pin", None)
         thickness = 1 * scale
 
         if element_id and self.current_dict_circuit.get(element_id):
@@ -2488,6 +2490,7 @@ class ComponentSketcher:
             self.canvas.move(element_id, dx, dy)
             params["XY"] = (x_origin, y_origin)
             params["color"] = color
+            params["assigned_pin"] = assigned_pin
 
         else:
             if "io" not in self.id_type:
@@ -2504,6 +2507,7 @@ class ComponentSketcher:
             params["controller_pin"] = "IO"
             params["type"] = element_type
             params["color"] = color
+            params["assigned_pin"] = assigned_pin
 
             # tags here
             pin_tag = f"pin_io_{element_id}"

--- a/component_sketch.py
+++ b/component_sketch.py
@@ -2475,7 +2475,6 @@ class ComponentSketcher:
         coord = kwargs.get("coord", [])
         element_type = kwargs.get("type", INPUT)
         color = kwargs.get("color", "#479dff")
-        assigned_pin = kwargs.get("assigned_pin", None)
         thickness = 1 * scale
 
         if element_id and self.current_dict_circuit.get(element_id):
@@ -2490,7 +2489,6 @@ class ComponentSketcher:
             self.canvas.move(element_id, dx, dy)
             params["XY"] = (x_origin, y_origin)
             params["color"] = color
-            params["assigned_pin"] = assigned_pin
 
         else:
             if "io" not in self.id_type:
@@ -2507,7 +2505,6 @@ class ComponentSketcher:
             params["controller_pin"] = "IO"
             params["type"] = element_type
             params["color"] = color
-            params["assigned_pin"] = assigned_pin
 
             # tags here
             pin_tag = f"pin_io_{element_id}"
@@ -2561,6 +2558,25 @@ class ComponentSketcher:
             # Bring the rhombus to the front
             self.canvas.tag_raise(element_id)
 
+            # take the last number of the element_id as the pin number as an integer
+            pin_number = element_id.split("_")[-1]
+
+            label_x = x_distance + x_origin + 5 * scale,
+            label_y = y_distance + y_origin - 48 * scale,
+
+            label_tag = f"{element_id}_label"
+            text_id = self.canvas.create_text(
+                label_x,
+                label_y,
+                text=pin_number,
+                font=("FiraCode-Bold", int(10 * scale)),
+                fill="#000000",
+                anchor="center",
+                tags=(element_id, label_tag),
+            )
+            params["label_tag"] = label_tag
+            params["tags"].append(text_id)
+
             if element_type == INPUT:
                 # Arrow pointing down
                 arrow_line_id = self.canvas.create_line(
@@ -2611,6 +2627,8 @@ class ComponentSketcher:
                     tags=(element_id, interactive_tag, outline_tag),
                 )
                 params["tags"].append(arrow_head_id)
+
+
 
             self.current_dict_circuit[element_id] = params
 

--- a/menus.py
+++ b/menus.py
@@ -13,6 +13,46 @@ import serial.tools.list_ports  # type: ignore
 
 from breadboard import Breadboard
 
+from dataCDLT import INPUT, OUTPUT
+
+MICROCONTROLLER_PINS = {
+    "Arduino Mega": {
+        "input_pins": [22, 23, 24, 25, 26, 27, 28, 29],
+        "output_pins": [32, 33, 34, 35, 36, 37],
+        "clock_pin": 2,
+    },
+    "Arduino Uno": {
+        "input_pins": [2, 3, 4, 5, 6, 7, 8, 9],
+        "output_pins": [10, 11, 12, 13],
+        "clock_pin": 2,
+    },
+    "Arduino Micro": {
+        "input_pins": [2, 3, 4, 5, 6, 7, 8, 9],
+        "output_pins": [10, 11, 12, 13],
+        "clock_pin": 2,
+    },
+    "Arduino Mini": {
+        "input_pins": [2, 3, 4, 5, 6, 7, 8, 9],
+        "output_pins": [10, 11, 12, 13],
+        "clock_pin": 2,
+    },
+    "STM32": {
+        "input_pins": ["PA0", "PA1", "PA2", "PA3", "PB0", "PB1", "PB2", "PB3"],
+        "output_pins": ["PC0", "PC1", "PC2", "PC3", "PC4", "PC5"],
+        "clock_pin": "PA0",
+    },
+    "NodeMCU ESP8266": {
+        "input_pins": ["D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8"],
+        "output_pins": ["D0", "D1", "D2", "D3", "D4", "D5"],
+        "clock_pin": "D2",
+    },
+    "NodeMCU ESP32": {
+        "input_pins": [32, 33, 34, 35, 25, 26, 27, 14],
+        "output_pins": [23, 22, 21, 19, 18, 5],
+        "clock_pin": 2,
+    },
+}
+
 
 class Menus:
     """
@@ -57,6 +97,8 @@ class Menus:
         """The zoom function to adjust the canvas."""
         self.com_port: str | None = None
         """The selected COM port."""
+        self.selected_microcontroller = None
+        """The selected microcontroller."""
 
         # Create the menu bar frame (do not pack here)
         self.menu_bar = tk.Frame(parent, bg="#333333")
@@ -65,8 +107,17 @@ class Menus:
         # Define menu items and their corresponding dropdown options
         menus = {
             "File": ["New", "Open", "Save", "Exit"],
-            "Controllers": ["Arduino", "ESP32"],
+            "Controllers": [
+                "Arduino Mega",
+                "Arduino Uno",
+                "Arduino Micro",
+                "Arduino Mini",
+                "STM32",
+                "NodeMCU ESP8266",
+                "NodeMCU ESP32"
+            ],
             "Ports": ["Configure Ports"],
+            "Export": ["Show Correspondence Table"],
             "Help": ["Documentation", "About"],
         }
 
@@ -76,9 +127,15 @@ class Menus:
             "Open": self.open_file,
             "Save": self.save_file,
             "Exit": self.parent.quit,
-            "Arduino": self.Arduino,
-            "ESP32": self.ESP32,
+            "Arduino Mega": lambda: self.select_microcontroller("Arduino Mega"),
+            "Arduino Uno": lambda: self.select_microcontroller("Arduino Uno"),
+            "Arduino Micro": lambda: self.select_microcontroller("Arduino Micro"),
+            "Arduino Mini": lambda: self.select_microcontroller("Arduino Mini"),
+            "STM32": lambda: self.select_microcontroller("STM32"),
+            "NodeMCU ESP8266": lambda: self.select_microcontroller("NodeMCU ESP8266"),
+            "NodeMCU ESP32": lambda: self.select_microcontroller("NodeMCU ESP32"),
             "Configure Ports": self.configure_ports,
+            "Show Correspondence Table": self.show_correspondence_table,
             "Documentation": self.open_documentation,
             "About": self.about,
         }
@@ -89,6 +146,63 @@ class Menus:
 
         # Bind to parent to close dropdowns when clicking outside
         self.parent.bind("<Button-1>", self.close_dropdown)
+
+    def select_microcontroller(self, microcontroller_name):
+        """Handler for microcontroller selection."""
+        print(f"{microcontroller_name} selected.")
+        self.selected_microcontroller = microcontroller_name
+        messagebox.showinfo("Microcontroller Selected", f"{microcontroller_name} has been selected.")
+
+    def show_correspondence_table(self):
+        """Displays the correspondence table between pin_io objects and microcontroller pins."""
+        if self.selected_microcontroller is None:
+            messagebox.showwarning("No Microcontroller Selected", "Please select a microcontroller first.")
+            return
+
+        pin_mappings = MICROCONTROLLER_PINS.get(self.selected_microcontroller)
+        if not pin_mappings:
+            messagebox.showerror("Error", f"No pin mappings found for {self.selected_microcontroller}.")
+            return
+
+        input_pins = pin_mappings["input_pins"]
+        output_pins = pin_mappings["output_pins"]
+
+        # Gather pin_io objects from current_dict_circuit
+        pin_ios = [value for key, value in self.current_dict_circuit.items() if key.startswith("_io_")]
+
+        # Separate pin_ios into inputs and outputs
+        input_pin_ios = [pin for pin in pin_ios if pin["type"] == INPUT]
+        output_pin_ios = [pin for pin in pin_ios if pin["type"] == OUTPUT]
+
+        # Check if we have more pin_ios than available pins
+        if len(input_pin_ios) > len(input_pins):
+            messagebox.showerror(
+                "Too Many Inputs",
+                f"You have {len(input_pin_ios)} input pin_ios but only {len(input_pins)} available input pins on the microcontroller.",
+            )
+            return
+        if len(output_pin_ios) > len(output_pins):
+            messagebox.showerror(
+                "Too Many Outputs",
+                f"You have {len(output_pin_ios)} output pin_ios but only {len(output_pins)} available output pins on the microcontroller.",
+            )
+            return
+
+        # Generate the correspondence table
+        correspondence = []
+        for idx, pin_io in enumerate(input_pin_ios):
+            mcu_pin = input_pins[idx]
+            correspondence.append(f"{pin_io['id']} (Input) --> MCU Pin {mcu_pin}")
+
+        for idx, pin_io in enumerate(output_pin_ios):
+            mcu_pin = output_pins[idx]
+            correspondence.append(f"{pin_io['id']} (Output) --> MCU Pin {mcu_pin}")
+
+        # Display the correspondence table
+        table_text = "\n".join(correspondence)
+        print("Correspondence Table:\n", table_text)
+        # Show in a message box or create a new window
+        messagebox.showinfo("Correspondence Table", table_text)
 
     def create_menu(self, menu_name, options, menu_commands):
         """

--- a/menus.py
+++ b/menus.py
@@ -154,7 +154,7 @@ class Menus:
         messagebox.showinfo("Microcontroller Selected", f"{microcontroller_name} has been selected.")
 
     def show_correspondence_table(self):
-        """Displays the correspondence table between pin_io objects and microcontroller pins."""
+        """Displays the correspondence table between pin_io objects and microcontroller pins in a table format."""
         if self.selected_microcontroller is None:
             messagebox.showwarning("No Microcontroller Selected", "Please select a microcontroller first.")
             return
@@ -188,21 +188,41 @@ class Menus:
             )
             return
 
-        # Generate the correspondence table
-        correspondence = []
+        # Create a new window for the correspondence table
+        table_window = tk.Toplevel(self.parent)
+        table_window.title("Correspondence Table")
+        table_window.geometry("400x300")
+
+        # Create a Treeview widget for the table
+        tree = ttk.Treeview(table_window, columns=("ID", "Type", "MCU Pin"), show="headings", height=10)
+        tree.pack(expand=True, fill="both", padx=10, pady=10)
+
+        # Define columns and headings
+        tree.column("ID", anchor="center", width=120)
+        tree.column("Type", anchor="center", width=80)
+        tree.column("MCU Pin", anchor="center", width=120)
+        tree.heading("ID", text="Pin IO ID")
+        tree.heading("Type", text="Type")
+        tree.heading("MCU Pin", text="MCU Pin")
+
+        # Populate the table with input and output pin mappings
         for idx, pin_io in enumerate(input_pin_ios):
             mcu_pin = input_pins[idx]
-            correspondence.append(f"{pin_io['id']} (Input) --> MCU Pin {mcu_pin}")
+            tree.insert("", "end", values=(pin_io["id"], "Input", mcu_pin))
 
         for idx, pin_io in enumerate(output_pin_ios):
             mcu_pin = output_pins[idx]
-            correspondence.append(f"{pin_io['id']} (Output) --> MCU Pin {mcu_pin}")
+            tree.insert("", "end", values=(pin_io["id"], "Output", mcu_pin))
 
-        # Display the correspondence table
-        table_text = "\n".join(correspondence)
-        print("Correspondence Table:\n", table_text)
-        # Show in a message box or create a new window
-        messagebox.showinfo("Correspondence Table", table_text)
+        # Add a scrollbar if the list gets too long
+        scrollbar = ttk.Scrollbar(table_window, orient="vertical", command=tree.yview)
+        tree.configure(yscroll=scrollbar.set)
+        scrollbar.pack(side="right", fill="y")
+
+        # Show the table in the new window
+        table_window.transient(self.parent)  # Set to be on top of the parent window
+        table_window.grab_set()  # Prevent interaction with the main window until closed
+        table_window.mainloop()
 
     def create_menu(self, menu_name, options, menu_commands):
         """

--- a/menus.py
+++ b/menus.py
@@ -208,11 +208,13 @@ class Menus:
         # Populate the table with input and output pin mappings
         for idx, pin_io in enumerate(input_pin_ios):
             mcu_pin = input_pins[idx]
-            tree.insert("", "end", values=(pin_io["id"], "Input", mcu_pin))
+            last_letter = pin_io["id"][-1]
+            tree.insert("", "end", values=(last_letter, "Input", mcu_pin))
 
         for idx, pin_io in enumerate(output_pin_ios):
             mcu_pin = output_pins[idx]
-            tree.insert("", "end", values=(pin_io["id"], "Output", mcu_pin))
+            last_letter = pin_io["id"][-1]
+            tree.insert("", "end", values=(last_letter, "Output", mcu_pin))
 
         # Add a scrollbar if the list gets too long
         scrollbar = ttk.Scrollbar(table_window, orient="vertical", command=tree.yview)

--- a/toolbar.py
+++ b/toolbar.py
@@ -52,6 +52,7 @@ class Toolbar:
         self.canvas.bind("<Motion>", self.canvas_follow_mouse, add="+")
         self.canvas.bind("<Button-1>", self.canvas_click, add="+")
         self.canvas.bind("<Button-3>", self.cancel_placement, add="+")
+        self.pin_io_list: list[dict[str, int]] = []
 
     def create_topbar(self, parent: tk.Tk):
         """
@@ -339,6 +340,8 @@ class Toolbar:
                 )
             ]
             self.sketcher.circuit(x_origin, y_origin, model=model_pin_io)
+            pin_io_id = self.current_dict_circuit["last_id"]
+            self.pin_io_list.append({"id": pin_io_id, "type": type_const})
             # Optionally deactivate after placement
             # self.cancel_pin_io_placement()
 


### PR DESCRIPTION
ajout de tables de correspondances de PIN avec les IO des microcontrolleurs:

1) placer les entrées et sorties dans la board
2) aller dans le menu controllers et selectionner un microcontrolleur
3) aller dans le menu export (qui va contronir le bouton de téléversement après) et appuier sur show correspondance

pour l'instant j'ai mis les numero des pin au dessus des objets pin_io mais il faudra trouver un meilleur layout pour que ce soit plus visible, j'ai créé un issue pour ça.
